### PR TITLE
Adds types for Prismic Integration Fields

### DIFF
--- a/packages/prismic-types/index.ts
+++ b/packages/prismic-types/index.ts
@@ -74,3 +74,19 @@ export type PrismicImage = {
   dimensions: { width: number, height: number }
   url: string
 }
+
+export type PrismicIntegrationField<BlobType> = {
+  id: string
+  title: string
+  description: string
+  image_url: string
+  last_update: number
+  blob: BlobType
+}
+
+export type PrismicIntegrationFields<BlobType> = PrismicIntegrationField<BlobType>[]
+
+export type PrismicIntegrationFieldAPIResponse<BlobType> = {
+  results_size: number
+  results: PrismicIntegrationFields<BlobType>
+}


### PR DESCRIPTION
I included simple types for the Prismic Integration Fields. Useful for example when creating an endpoint for Prismic Integration Fields with Next.js API routes.

An example of the required API response and other documentation for Integration Fields available [here](https://prismic.io/docs/core-concepts/integration-fields-setup).